### PR TITLE
Issue 2686 Multiple charts using ContinuousColorsLegendSvg share the …

### DIFF
--- a/packages/legends/src/svg/ContinuousColorsLegendSvg.tsx
+++ b/packages/legends/src/svg/ContinuousColorsLegendSvg.tsx
@@ -52,8 +52,10 @@ export const ContinuousColorsLegendSvg = ({
 
     const theme = useTheme()
 
+    // remove commas, parentheses and spaces from stop color, this will then create a unique id depending on which color scheme you use.
+    // so if you have two or more heatmaps on a single page with differing color schemes the legend will be correct for each.
     const id = `ContinuousColorsLegendSvgGradient.${direction}.${colorStops
-        .map(stop => stop.offset)
+        .map(stop => `${stop.stopColor.replace(/[(),\s]/g, '')}.${stop.offset}`)
         .join('_')}`
 
     return (

--- a/storybook/stories/heatmap/HeatMap.stories.tsx
+++ b/storybook/stories/heatmap/HeatMap.stories.tsx
@@ -100,6 +100,15 @@ export const CustomTooltip: Story = {
     ),
 }
 
+export const MultipleHeatMaps: Story = {
+    render: () => (
+        <>
+            <HeatMapWithColor colorConfig={'sequential (full domain)'} />
+            <HeatMapWithColor colorConfig={'diverging at 0.5'} />
+        </>
+    ),
+}
+
 const customColorConfigs = {
     'sequential (full domain)': {
         type: 'sequential',


### PR DESCRIPTION
Description

"@nivo/core": "0.88.0",
"@nivo/heatmap": "0.88.0",
Multiple charts using ContinuousColorsLegendSvg (like Heatmap) share the same legend color scale even if differing colors were passed to them as props.

To Reproduce
CodeSandbox showcasing the bug: https://codesandbox.io/p/sandbox/nivo-legends-bug-y6l5kd

Steps to reproduce the behavior:

Create a project with 2 or more Heatmap charts
Pass them the required props along with 1 legend for each chart
Define differing colors for each chart
Notice that all charts share the same color scale for their legends
Expected behavior
Each chart's legend to inherit the chart's coloring and not share the same color scale.

Screenshots
Image

Additional context
The bug appears to come from the non-unique id generation inside ContinuousColorsLegendSvg resulting in an id conflict inside the DOM.

[nivo/packages/legends/src/svg/ContinuousColorsLegendSvg.tsx](https://github.com/plouc/nivo/blob/af226890ae7239eca26cc8c70759506448c02c53/packages/legends/src/svg/ContinuousColorsLegendSvg.tsx#L55)

Line 55 in [af22689](https://github.com/plouc/nivo/commit/af226890ae7239eca26cc8c70759506448c02c53)

 const id = `ContinuousColorsLegendSvgGradient.${direction}.${colorStops